### PR TITLE
Avoid loading the tokenizer twice

### DIFF
--- a/Scripts/modeling/load_modeling.py
+++ b/Scripts/modeling/load_modeling.py
@@ -2,47 +2,27 @@ import transformers
 import torch
 
 def load_tokenizer(args, task, fold=None):
-    if task == "fill-mask":
-        model_checkpoint = f"bert-{args.model.split('-')[0]}-uncased"
-    elif task == "text classification":
-        if 'masking' in args.pipeline:
-            model_checkpoint = f"plantbert_fill_mask_model_{args.model}_{args.method}_{args.batch_size}_{args.learning_rate}_{fold}"
-        else:
-            model_checkpoint = f"bert-{args.model}-uncased"
-    else:
-        if task == "predict habitat":
-            model_checkpoint = args.model_habitat
-        else:
-            model_checkpoint = args.model_species
-    tokenizer = transformers.AutoTokenizer.from_pretrained(f'../Models/{model_checkpoint}/')
+    model_path = _model_path(args, task)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
     return tokenizer
 
 def load_model(args, task, fold=None, tokenizer=None, dataset=None):
+    model_path = _model_path(args, task)
     if task == "fill-mask":
-        model_checkpoint = f"bert-{args.model.split('-')[0]}-uncased"
-        model = transformers.AutoModelForMaskedLM.from_pretrained(f'../Models/{model_checkpoint}/')
+        model = transformers.AutoModelForMaskedLM.from_pretrained(model_path)
         model.resize_token_embeddings(len(tokenizer))
-        return model
     elif task == "text classification":
-        if 'masking' in args.pipeline:
-            model_checkpoint = f"plantbert_fill_mask_model_{args.model}_{args.method}_{args.batch_size}_{args.learning_rate}_{fold}"
-        else:
-            model_checkpoint = f"bert-{args.model}-uncased"
         labels = dataset['train'].features['labels'].names
         id2label = {i: label for i, label in enumerate(labels)}
         label2id = {label: i for i, label in enumerate(labels)}
-        config = transformers.AutoConfig.from_pretrained(f'../Models/{model_checkpoint}/', label2id=label2id, id2label=id2label)
-        model = transformers.AutoModelForSequenceClassification.from_pretrained(f'../Models/{model_checkpoint}/', config=config)
+        config = transformers.AutoConfig.from_pretrained(model_path, label2id=label2id, id2label=id2label)
+        model = transformers.AutoModelForSequenceClassification.from_pretrained(model_path, config=config)
         return model, config
+    elif task == "predict habitat":
+        model = transformers.pipeline("text-classification", model=model_path, tokenizer=model_path, top_k=args.k_habitat)
     else:
-        if task == "predict habitat":
-            model_checkpoint = args.model_habitat
-            model = transformers.pipeline("text-classification", model=f"../Models/{model_checkpoint}", tokenizer=f"../Models/{model_checkpoint}", top_k=args.k_habitat)
-            return model
-        else:
-            model_checkpoint = args.model_species
-            model = transformers.pipeline("fill-mask", model=f"../Models/{model_checkpoint}", tokenizer=f"../Models/{model_checkpoint}", top_k=10*args.k_species)
-            return model
+        model = transformers.pipeline("fill-mask", model=model_path, tokenizer=model_path, top_k=10*args.k_species)
+    return model
 
 def load_optimizer(args, model):
     learning_rate = float(args.learning_rate)
@@ -54,3 +34,19 @@ def load_scheduler(args, train_dataloader, optimizer):
     num_training_steps = args.epochs * num_update_steps_per_epoch
     lr_scheduler = transformers.get_scheduler("linear", optimizer=optimizer, num_warmup_steps=0, num_training_steps=num_training_steps)
     return lr_scheduler
+
+# Helper function for model paths for loading either tokenizer or model
+def _model_path(args, task):
+    if task == "fill-mask":
+        model_checkpoint = f"bert-{args.model.split('-')[0]}-uncased"
+    elif task == "text classification":
+        if 'masking' in args.pipeline:
+            model_checkpoint = f"plantbert_fill_mask_model_{args.model}_{args.method}_{args.batch_size}_{args.learning_rate}_{fold}"
+        else:
+            model_checkpoint = f"bert-{args.model}-uncased"
+    else:
+        if task == "predict habitat":
+            model_checkpoint = args.model_habitat
+        else:
+            model_checkpoint = args.model_species
+    return f"../Models/{model_checkpoint}"

--- a/Scripts/pipelines/inference.py
+++ b/Scripts/pipelines/inference.py
@@ -16,14 +16,13 @@ class MakePredictions:
 
     def predict_habitat(self, args, vegetation_plots):
         model = load_model(args, "predict habitat")
-        tokenizer = load_tokenizer(args, "predict habitat")
-        predictions, elapsed_time = make_predictions(args, vegetation_plots, model, tokenizer, "predict habitat")
+        predictions, elapsed_time = make_predictions(args, vegetation_plots, model, model.tokenizer, "predict habitat")
         return predictions, elapsed_time
 
     def predict_species(self, args, vegetation_plots):
         model = load_model(args, "predict species")
-        tokenizer = load_tokenizer(args, "predict species")
-        predictions, scores, positions, completed_plots, elapsed_time =  make_predictions(args, vegetation_plots, model, tokenizer, "predict species")
+        predictions, scores, positions, completed_plots, elapsed_time = make_predictions(
+            args, vegetation_plots, model, model.tokenizer, "predict species")
         return predictions, scores, positions, completed_plots, elapsed_time
 
     def write_predictions(self, vegetation_plots, type, predictions, scores=None, positions=None, completed_plots=None):


### PR DESCRIPTION
For predicting habitats or species, pipelines are loaded from the saved models through load_model - and right after the tokenizer is loaded seperately. Since the tokenizer is part of the pipeline this is not necessary, it can just be accessed as `model.tokenizer`.

I also streamlined the code for load_model and load_tokenizer a little bit to put code for getting the path to the model file in a helper function so it is not duplicated between load_model and load_tokenizer